### PR TITLE
Extend CDN TTL to one year

### DIFF
--- a/src/EventSubscriber/CacheHeadersSubscriber.php
+++ b/src/EventSubscriber/CacheHeadersSubscriber.php
@@ -50,10 +50,10 @@ final class CacheHeadersSubscriber implements EventSubscriberInterface {
     }
 
     // don't let browsers cache HTML responses
-    // cdn can cache responses for one day
+    // cdn can cache responses for one year
     // cdn can serve stale cache for one day
     // since we're setting s-maxage, we don't need the public directive
-    $response->headers->set('Cache-Control', 'max-age=0, s-maxage=86400, stale-while-revalidate=86400');
+    $response->headers->set('Cache-Control', 'max-age=0, s-maxage=31536000, stale-while-revalidate=86400');
     // satisfy https://cloud.google.com/cdn/docs/caching#non-cacheable_content
     // make sure google cloud cdn adds Vary: cookie header in response
     if ($response->headers->get('Vary') == 'Cookie') {


### PR DESCRIPTION
Now that we're properly purging cache, we can set the CDN TTL to one year and invalidate when needed.

## Issue IDs
https://github.com/LibOps/docs/issues/9